### PR TITLE
Authentication / authorization for analysts

### DIFF
--- a/src/static/config.yml
+++ b/src/static/config.yml
@@ -1,6 +1,7 @@
 backend:
   name: git-gateway
   branch: master
+publish_mode: editorial_workflow
 media_folder: src/assets
 public_folder: /assets
 collections:


### PR DESCRIPTION
It seems, the best way is to restrict the `master` branch to reviewed pull requests only...
<https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches>

<img width="955" alt="Screenshot_20220718_192441" src="https://user-images.githubusercontent.com/109149821/179653754-b3cf085f-7bca-4c46-a594-6fb686246784.png">
It looks pretty descriptive and could be polished in future at least...